### PR TITLE
Update APIGatewayProxy types to better support APIGateway integration

### DIFF
--- a/lambda-events/src/commonMain/kotlin/io/github/trueangle/knative/lambda/runtime/events/apigateway/APIGatewayProxy.kt
+++ b/lambda-events/src/commonMain/kotlin/io/github/trueangle/knative/lambda/runtime/events/apigateway/APIGatewayProxy.kt
@@ -1,11 +1,11 @@
 package io.github.trueangle.knative.lambda.runtime.events.apigateway
 
-import kotlinx.serialization.Serializable
 import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
 
 @Serializable
 data class APIGatewayProxy(
-    @SerialName("version") val version: String,
+    @SerialName("version") val version: String?,
     @SerialName("resource") val resource: String?,
     @SerialName("path") val path: String?,
     @SerialName("httpMethod") val httpMethod: String,
@@ -30,6 +30,7 @@ data class APIGatewayProxy(
         @SerialName("resourcePath") val resourcePath: String?,
         @SerialName("httpMethod") val httpMethod: String,
         @SerialName("apiId") val apiId: String?,
+        @SerialName("deploymentId") val deploymentId: String?,
         @SerialName("path") val path: String?,
         @SerialName("authorizer") val authorizer: Map<String, Map<String, String>>?,
         @SerialName("extendedRequestId") val extendedRequestId: String?,


### PR DESCRIPTION
Hey,

Sorry I was trying to get this in earlier (saw that you just cut a release). But I am getting some serialization errors when integrating with API Gateway. It seems like in my [setup](https://github.com/zfz7/tetris_aws) API Gateway is providing a `deploymentId` and has a null `version`

Missing `deploymentId`  logs:

```
START RequestId: 10043724-77f3-4c74-b3e0-fae7ffb2b79a Version: $LATEST
[ERROR] | An exception occurred:
Message: Illegal input: Encountered an unknown key 'deploymentId' at offset 2500 at path: $.requestContext
Use 'ignoreUnknownKeys = true' in 'Json {}' builder or '@JsonIgnoreUnknownKeys' annotation to ignore unknown keys.
JSON input: .....me":"api.daniel-eichman.com","deploymentId":"ffyam4","apiId".....
Stack Trace:
EventBodyParseException(cause=io.ktor.serialization.JsonConvertException: Illegal input: Encountered an unknown key 'deploymentId' at offset 2500 at path: $.requestContext
Use 'ignoreUnknownKeys = true' in 'Json {}' builder or '@JsonIgnoreUnknownKeys' annotation to ignore unknown keys.
```
Null `version` logs:

```
START RequestId: 24977765-5edd-44ba-87d1-0c6c1fc05d96 Version: $LATEST
[ERROR] | An exception occurred:
Message: Illegal input: Field 'version' is required for type with serial name 'com.backend.apigateway.APIGatewayProxy', but it was missing at path: $
Stack Trace:
EventBodyParseException(cause=io.ktor.serialization.JsonConvertException: Illegal input: Field 'version' is required for type with serial name 'com.backend.apigateway.APIGatewayProxy', but it was missing at path: $, context=Context(awsRequestId=24977765-5edd-44ba-87d1-0c6c1fc05d96, xrayTracingId=Root=1-67b25f47-4d1cd7ed332b0e2f3725c857;Parent=4276dcbc09f509dd;Sampled=0;Lineage=1:ffc3a1c7:0, deadlineTimeInMs=1739743050945, invokedFunctionArn=arn:aws:lambda:us-west-2:<AWS_ACCOUNT>:function:Tetris-Service-Stack-Beta-TetrisApiLambdaBB313040-X7ZlUgkFQ3O0, invokedFunctionName=Tetris-Service-Stack-Beta-TetrisApiLambdaBB313040-X7ZlUgkFQ3O0, invokedFunctionVersion=$LATEST, memoryLimitMb=128, clientContext=null, cognitoIdentity=null), message=Illegal input: Field 'version' is required for type with serial name 'com.backend.apigateway.APIGatewayProxy', but it was missing at path: $, type=Runtime.InvalidEventBodyError)
```

###Testing

- ` ./gradlew build`
- Deployed to AWS and was able to resolve API requests