### PR TITLE
Enabled ARM support 

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,8 +11,8 @@ A runtime for executing AWS Lambda Functions written in Kotlin/Native, designed 
 
 ## Supported [OS-only runtime machines](https://docs.aws.amazon.com/lambda/latest/dg/lambda-runtimes.html)
 
-- Amazon Linux 2023 (provided.al2023) with x86_64 architecture
-- Amazon Linux 2 (provided.al2) with x86_64 architecture
+- Amazon Linux 2023 (provided.al2023) with x86_64 or ARM architecture
+- Amazon Linux 2 (provided.al2) with x86_64 or ARM architecture
 
 ## Performance
 
@@ -151,6 +151,7 @@ $ aws lambda create-function --function-name LAMBDA_FUNCTION_NAME \
   --handler YOUR_MODULE_NAME.kexe \ # Important to specify the name of the Lambda executable. 
   --zip-file YOUR_MODULE_NAME.zip \
   --runtime provided.al2023 \ # Change this to provided.al2 if you would like to use Amazon Linux 2
+  --architecture x86_64 \ # or arm64
   --role arn:aws:iam::XXXXXXXXXXXXX:role/YOUR_LAMBDA_EXECUTION_ROLE \
   --tracing-config Mode=Active
 ```

--- a/gradle-plugin/src/main/kotlin/LambdaPlugin.kt
+++ b/gradle-plugin/src/main/kotlin/LambdaPlugin.kt
@@ -1,16 +1,55 @@
 import org.gradle.api.DefaultTask
 import org.gradle.api.Plugin
 import org.gradle.api.Project
+import org.gradle.api.provider.Property
+import org.gradle.api.tasks.Input
 import org.gradle.api.tasks.TaskAction
+import org.gradle.kotlin.dsl.property
 import java.io.File
 
 class LambdaPlugin : Plugin<Project> {
     override fun apply(project: Project) {
-        project.tasks.create("buildLambdaRelease", LambdaPackagerTask::class.java)
+        project.run {
+            val buildLambdaRelease = extensions.create(
+                "buildLambdaRelease",
+                LambdaPackagerExtension::class.java,
+                project
+            )
+            tasks.apply {
+                register("buildLambdaRelease", LambdaPackagerTask::class.java).configure {
+                    architecture.set(buildLambdaRelease.architecture)
+                }
+            }
+        }
+    }
+}
+
+enum class Architecture(val path: String) {
+    LINUX_X64("linuxX64"),
+    LINUX_ARM64("linuxArm64");
+
+    override fun toString(): String = path
+}
+
+/**
+ * Gradle project level extension object definition for the LambdaPackagerTask
+ *
+ */
+open class LambdaPackagerExtension(project: Project) {
+    /**
+     * The architecture of the desired Lambda runtime, default: LINUX_X64
+     */
+    val architecture = project.objects.property<Architecture>()
+
+    init {
+        architecture.set(Architecture.LINUX_X64)
     }
 }
 
 abstract class LambdaPackagerTask : DefaultTask() {
+    @Input
+    val architecture: Property<Architecture> =
+        project.objects.property(Architecture::class.java).convention(Architecture.LINUX_X64)
 
     @TaskAction
     fun packageLambda() {
@@ -20,7 +59,7 @@ abstract class LambdaPackagerTask : DefaultTask() {
         }
 
         val buildDir = project.layout.buildDirectory
-        val executableDir = project.file(buildDir.dir("bin/linuxX64/releaseExecutable"))
+        val executableDir = project.file(buildDir.dir("bin/${architecture.get()}/releaseExecutable"))
         val executable = executableDir
             .listFiles()
             ?.first { it.name.endsWith(".kexe") }

--- a/lambda-events/build.gradle.kts
+++ b/lambda-events/build.gradle.kts
@@ -8,7 +8,7 @@ plugins {
 kotlin {
     macosArm64()
     macosX64()
-    //linuxArm64() // https://youtrack.jetbrains.com/issue/KT-36871/Support-Aarch64-Linux-as-a-host-for-the-Kotlin-Native
+    linuxArm64()
     linuxX64()
 
     sourceSets {

--- a/lambda-runtime/build.gradle.kts
+++ b/lambda-runtime/build.gradle.kts
@@ -14,7 +14,7 @@ plugins {
 kotlin {
     macosArm64()
     macosX64()
-    //linuxArm64() // https://youtrack.jetbrains.com/issue/KT-36871/Support-Aarch64-Linux-as-a-host-for-the-Kotlin-Native
+    linuxArm64()
     linuxX64()
 
     @OptIn(ExperimentalKotlinGradlePluginApi::class)

--- a/sample/build.gradle.kts
+++ b/sample/build.gradle.kts
@@ -8,7 +8,7 @@ kotlin {
     listOf(
         macosArm64(),
         macosX64(),
-        //linuxArm64(), // https://youtrack.jetbrains.com/issue/KT-36871/Support-Aarch64-Linux-as-a-host-for-the-Kotlin-Native
+        linuxArm64(),
         linuxX64(),
     ).forEach {
         it.binaries {
@@ -26,4 +26,8 @@ kotlin {
             implementation(libs.kotlin.serialization.json)
         }
     }
+}
+
+buildLambdaRelease {
+    architecture.set(Architecture.LINUX_X64) // or Architecture.LINUX_ARM64
 }


### PR DESCRIPTION
Hey,

I wanted to add support for the ARM runtime. I updated the `LambdaPackagerTask` plugin to add support for a `architecture` param. You can configure the the `buildLambdaRelease` task like:

```
buildLambdaRelease {
    architecture.set(Architecture.LINUX_X64) // or Architecture.LINUX_ARM64
}
```

### Testing X86

```
./gradlew clean buildLambdaRelease // built with x86 

aws lambda create-function --function-name Kotlin-Native \ 
--handler sample.kexe --zip-file fileb:///Users/daniel/workspace/kotlin-native-aws-lambda-runtime/sample/build/lambda/release/sample.zip  \ 
--runtime provided.al2 \
--architecture x86_64 \
--role arn:aws:iam::<AWS_ACC>:role/<ROLE_NAME \
--tracing-config Mode=Active

aws lambda invoke --cli-binary-format raw-in-base64-out --function-name Kotlin-Native --payload '{"command": "Say Hi!"}' output.json 

cat output.json
{
                 "statusCode": 200,
                 "headers": {
                   "Content-Type": "application/json"
                 },
                 "isBase64Encoded": false,
                 "body": "Hello world"
             }
```

### Testing ARM

```
./gradlew clean buildArmLambda // built with ARM by updating build.gradle.kts in sample project

aws lambda create-function --function-name Kotlin-Native \ 
--handler sample.kexe --zip-file fileb:///Users/daniel/workspace/kotlin-native-aws-lambda-runtime/sample/build/lambda/release/sample.zip  \ 
--runtime provided.al2 \
--architecture arm64 \
--role arn:aws:iam::<AWS_ACC>:role/<ROLE_NAME \
--tracing-config Mode=Active

aws lambda invoke --cli-binary-format raw-in-base64-out --function-name Kotlin-Native --payload '{"command": "Say Hi!"}' output.json 

cat output.json
{
                 "statusCode": 200,
                 "headers": {
                   "Content-Type": "application/json"
                 },
                 "isBase64Encoded": false,
                 "body": "Hello world"
             }
```

### Question 
- I would love to add a `bundleLibcrypt` param or `runtime` param that will pull the `libcrypt.so.1` into the zip file, but wasn't sure if thats possible / something you would want to do.
